### PR TITLE
fix(analyzer): apply [analysis].exclude during analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,9 +28,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -34,15 +43,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -53,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -64,8 +73,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "atomic-waker"
@@ -133,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -148,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -194,18 +209,19 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -220,6 +236,16 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -256,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -266,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -278,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -290,15 +316,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "cpufeatures"
@@ -311,25 +337,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -337,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -415,14 +440,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -478,14 +515,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
  "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -507,21 +545,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -606,13 +647,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.12.1"
+name = "id-arena"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -622,17 +671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -653,40 +691,46 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.178"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -702,9 +746,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -744,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -769,6 +813,16 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -824,34 +878,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.103"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -869,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -881,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -898,9 +962,9 @@ checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rust-embed"
@@ -938,15 +1002,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -972,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -1036,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -1067,6 +1131,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,9 +1160,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1107,31 +1177,31 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1175,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.11+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1190,27 +1260,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -1288,9 +1358,15 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -1322,18 +1398,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1344,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1354,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1367,22 +1452,72 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.83"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -1390,8 +1525,14 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -1484,30 +1625,112 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1516,6 +1739,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.12"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["development-tools", "command-line-utilities"]
 syn = { version = "2.0", features = ["full", "visit"] }
 walkdir = "2.5"
 thiserror = "2.0"
-clap = { version = "4.5", features = ["derive"] }
-cargo_metadata = "0.19"
+clap = { version = "4.6", features = ["derive"] }
+cargo_metadata = "0.23"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rayon = "1.10"
+rayon = "1.12"
 glob = "0.3"
-toml = "0.9"
+toml = "1.1"
 regex-lite = "0.1"
 
 # Web UI
@@ -30,8 +30,8 @@ mime_guess = "2"
 open = "5"
 
 [dev-dependencies]
-tempfile = "3.24"
-criterion = { version = "0.5", features = ["html_reports"] }
+tempfile = "3.27"
+criterion = { version = "0.8", features = ["html_reports"] }
 
 [[bench]]
 name = "analysis_benchmark"

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -7,7 +7,7 @@
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use rayon::prelude::*;
 use syn::visit::Visit;
@@ -18,6 +18,7 @@ use syn::{
 use thiserror::Error;
 use walkdir::WalkDir;
 
+use crate::config::CompiledConfig;
 use crate::metrics::{
     CouplingMetrics, Distance, IntegrationStrength, ModuleMetrics, ProjectMetrics, Visibility,
     Volatility,
@@ -1048,6 +1049,48 @@ pub fn analyze_project(path: &Path) -> Result<ProjectMetrics, AnalyzerError> {
     analyze_project_parallel(path)
 }
 
+/// Check whether a file path should be excluded according to `[analysis].exclude` patterns.
+///
+/// Patterns are evaluated relative to the directory that contained `.coupling.toml`
+/// when known; otherwise they fall back to the analysis root. Paths are normalized
+/// to forward slashes for consistent glob matching on Windows.
+fn is_path_excluded(file_path: &Path, exclude_base: &Path, config: &CompiledConfig) -> bool {
+    let normalized_file = normalize_exclude_path(file_path);
+    let normalized_base = normalize_exclude_path(exclude_base);
+    let relative = normalized_file
+        .strip_prefix(&normalized_base)
+        .unwrap_or(&normalized_file);
+    let relative_str = relative.to_string_lossy().replace('\\', "/");
+    config.should_exclude(&relative_str)
+}
+
+/// Normalize a path for exclude matching without resolving symlinks.
+///
+/// This keeps `./src`, `/tmp/foo`, and other caller-provided forms comparable
+/// by making them absolute and removing `.` / `..` components lexically.
+fn normalize_exclude_path(path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    };
+
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+
+    normalized
+}
+
 /// Get an iterator over all Rust source files in `dir`, excluding hidden directories and `target/`.
 ///
 /// Uses relative paths for filtering to avoid false positives when the project
@@ -1080,12 +1123,24 @@ fn rs_files(dir: &Path) -> impl Iterator<Item = PathBuf> {
 /// Automatically scales to available CPU cores. The parallel processing
 /// uses work-stealing for optimal load balancing across cores.
 pub fn analyze_project_parallel(path: &Path) -> Result<ProjectMetrics, AnalyzerError> {
+    analyze_project_parallel_with_config(path, &CompiledConfig::empty())
+}
+
+/// Analyze a project in parallel, honoring `[analysis].exclude` patterns from config.
+pub fn analyze_project_parallel_with_config(
+    path: &Path,
+    config: &CompiledConfig,
+) -> Result<ProjectMetrics, AnalyzerError> {
     if !path.exists() {
         return Err(AnalyzerError::InvalidPath(path.display().to_string()));
     }
 
-    // Collect all .rs file paths first (sequential, but fast)
-    let file_paths: Vec<PathBuf> = rs_files(path).collect();
+    let exclude_base = config.config_root().unwrap_or(path);
+
+    // Collect all .rs file paths first (sequential, but fast), applying exclude patterns.
+    let file_paths: Vec<PathBuf> = rs_files(path)
+        .filter(|fp| !is_path_excluded(fp, exclude_base, config))
+        .collect();
 
     // Calculate optimal chunk size based on file count and available parallelism
     // Smaller chunks = better load balancing, but more overhead
@@ -1232,6 +1287,14 @@ pub fn analyze_project_parallel(path: &Path) -> Result<ProjectMetrics, AnalyzerE
 
 /// Analyze a workspace using cargo metadata for better accuracy
 pub fn analyze_workspace(path: &Path) -> Result<ProjectMetrics, AnalyzerError> {
+    analyze_workspace_with_config(path, &CompiledConfig::empty())
+}
+
+/// Analyze a workspace, honoring `[analysis].exclude` patterns from config.
+pub fn analyze_workspace_with_config(
+    path: &Path,
+    config: &CompiledConfig,
+) -> Result<ProjectMetrics, AnalyzerError> {
     // Try to get workspace info
     let workspace = match WorkspaceInfo::from_path(path) {
         Ok(ws) => Some(ws),
@@ -1243,18 +1306,23 @@ pub fn analyze_workspace(path: &Path) -> Result<ProjectMetrics, AnalyzerError> {
     };
 
     if let Some(ws) = workspace {
-        analyze_with_workspace(path, &ws)
+        analyze_with_workspace(path, &ws, config)
     } else {
         // Fall back to basic analysis
-        analyze_project(path)
+        analyze_project_parallel_with_config(path, config)
     }
 }
 
 /// Analyze project with workspace information (parallel version)
 fn analyze_with_workspace(
-    _path: &Path,
+    _project_root: &Path,
     workspace: &WorkspaceInfo,
+    config: &CompiledConfig,
 ) -> Result<ProjectMetrics, AnalyzerError> {
+    // Exclude patterns are rooted at the config file when known. Otherwise fall back
+    // to the workspace root returned by `cargo metadata`.
+    let exclude_base = config.config_root().unwrap_or(workspace.root.as_path());
+
     let mut project = ProjectMetrics::new();
 
     // Store workspace info for the report
@@ -1280,6 +1348,9 @@ fn analyze_with_workspace(
 
             let src_root = crate_info.src_path.clone();
             for file_path in rs_files(&crate_info.src_path) {
+                if is_path_excluded(&file_path, exclude_base, config) {
+                    continue;
+                }
                 file_crate_pairs.push((
                     file_path.to_path_buf(),
                     member_name.clone(),
@@ -2145,5 +2216,165 @@ mod tests {
         } else {
             panic!("Expected module");
         }
+    }
+
+    /// Regression test for Issue #39: `[analysis].exclude` patterns must be applied during analysis.
+    ///
+    /// We assert on module names (not just `total_files`) so the test distinguishes
+    /// "excluded by config" from "silently dropped due to parse failure".
+    /// Both `src/generated/*` and `src/generated/**` are kept to mirror the reporter's repro.
+    #[test]
+    fn test_analyze_project_parallel_applies_exclude_patterns() {
+        use crate::config::{CompiledConfig, CouplingConfig};
+
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let root = tmp.path();
+        let src = root.join("src");
+        let generated = src.join("generated");
+        std::fs::create_dir_all(&generated).expect("create generated dir");
+        std::fs::write(src.join("lib.rs"), "pub mod generated;\npub fn call() {}\n")
+            .expect("write lib.rs");
+        std::fs::write(generated.join("mod.rs"), "pub fn helper() {}\n")
+            .expect("write generated/mod.rs");
+
+        // Baseline: with empty config both files are analyzed, including the generated module.
+        let baseline = analyze_project_parallel_with_config(root, &CompiledConfig::empty())
+            .expect("baseline analysis");
+        assert_eq!(baseline.total_files, 2, "both files should be analyzed");
+        assert!(
+            baseline.modules.keys().any(|k| k.contains("generated")),
+            "baseline must include the generated module; saw {:?}",
+            baseline.modules.keys().collect::<Vec<_>>()
+        );
+
+        // With exclude patterns the generated file is filtered out by config.
+        let toml = r#"
+            [analysis]
+            exclude = ["src/generated/*", "src/generated/**"]
+        "#;
+        let config: CouplingConfig = toml::from_str(toml).expect("parse toml");
+        let compiled = CompiledConfig::from_config(config).expect("compile config");
+        let filtered =
+            analyze_project_parallel_with_config(root, &compiled).expect("filtered analysis");
+        assert_eq!(
+            filtered.total_files, 1,
+            "generated file should be excluded from analysis"
+        );
+        assert!(
+            !filtered.modules.keys().any(|k| k.contains("generated")),
+            "no generated module should remain; saw {:?}",
+            filtered.modules.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// Regression test for Issue #39 on the CLI/workspace path:
+    /// a relative `./src`-style path must still apply `[analysis].exclude`.
+    #[test]
+    fn test_analyze_workspace_applies_exclude_patterns_from_relative_src_path() {
+        use crate::config::{CompiledConfig, load_compiled_config};
+
+        let current_dir = std::env::current_dir().expect("get current dir");
+        let target_dir = current_dir.join("target");
+        let tmp = tempfile::Builder::new()
+            .prefix("issue39-workspace-")
+            .tempdir_in(&target_dir)
+            .expect("create tempdir in target");
+        let root = tmp.path();
+        let src = root.join("src");
+        let generated = src.join("generated");
+        std::fs::create_dir_all(&generated).expect("create generated dir");
+        std::fs::write(
+            root.join("Cargo.toml"),
+            r#"[package]
+name = "coupling-fixture-exclude"
+version = "0.1.0"
+edition = "2024"
+"#,
+        )
+        .expect("write Cargo.toml");
+        std::fs::write(
+            root.join(".coupling.toml"),
+            "[analysis]\nexclude = [\"src/generated/*\", \"src/generated/**\"]\n",
+        )
+        .expect("write .coupling.toml");
+        std::fs::write(
+            src.join("lib.rs"),
+            "pub mod generated;\npub fn call() { generated::helper(); }\n",
+        )
+        .expect("write lib.rs");
+        std::fs::write(generated.join("mod.rs"), "pub fn helper() {}\n")
+            .expect("write generated/mod.rs");
+
+        let relative_src = src
+            .strip_prefix(&current_dir)
+            .expect("temp crate should be under current dir");
+
+        let baseline = analyze_workspace_with_config(relative_src, &CompiledConfig::empty())
+            .expect("baseline workspace analysis");
+        assert_eq!(baseline.total_files, 2, "both files should be analyzed");
+        assert!(
+            baseline.modules.keys().any(|k| k.contains("generated")),
+            "baseline must include the generated module; saw {:?}",
+            baseline.modules.keys().collect::<Vec<_>>()
+        );
+
+        let compiled = load_compiled_config(relative_src).expect("load compiled config");
+        let filtered = analyze_workspace_with_config(relative_src, &compiled)
+            .expect("filtered workspace analysis");
+        assert_eq!(
+            filtered.total_files, 1,
+            "generated file should be excluded from workspace analysis"
+        );
+        assert!(
+            !filtered.modules.keys().any(|k| k.contains("generated")),
+            "no generated module should remain; saw {:?}",
+            filtered.modules.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// Regression test for the non-workspace fallback path:
+    /// when analyzing `./src`, exclude patterns must still be rooted at the config file.
+    #[test]
+    fn test_basic_analysis_fallback_applies_exclude_patterns_from_config_root() {
+        use crate::config::{CompiledConfig, load_compiled_config};
+
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let root = tmp.path();
+        let src = root.join("src");
+        let generated = src.join("generated");
+        std::fs::create_dir_all(&generated).expect("create generated dir");
+        std::fs::write(
+            root.join(".coupling.toml"),
+            "[analysis]\nexclude = [\"src/generated/*\", \"src/generated/**\"]\n",
+        )
+        .expect("write .coupling.toml");
+        std::fs::write(
+            src.join("lib.rs"),
+            "pub mod generated;\npub fn call() { generated::helper(); }\n",
+        )
+        .expect("write lib.rs");
+        std::fs::write(generated.join("mod.rs"), "pub fn helper() {}\n")
+            .expect("write generated/mod.rs");
+
+        let baseline = analyze_workspace_with_config(&src, &CompiledConfig::empty())
+            .expect("baseline analysis");
+        assert_eq!(baseline.total_files, 2, "both files should be analyzed");
+        assert!(
+            baseline.modules.keys().any(|k| k.contains("generated")),
+            "baseline must include the generated module; saw {:?}",
+            baseline.modules.keys().collect::<Vec<_>>()
+        );
+
+        let compiled = load_compiled_config(&src).expect("load compiled config");
+        let filtered = analyze_workspace_with_config(&src, &compiled).expect("filtered analysis");
+        assert_eq!(
+            filtered.total_files, 1,
+            "generated file should be excluded from fallback analysis"
+        );
+        assert!(
+            !filtered.modules.keys().any(|k| k.contains("generated")),
+            "no generated module should remain; saw {:?}",
+            filtered.modules.keys().collect::<Vec<_>>()
+        );
     }
 }

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -251,7 +251,7 @@ pub fn calculate_hotspots(
     }
 
     // Sort by score descending
-    hotspots.sort_by(|a, b| b.score.cmp(&a.score));
+    hotspots.sort_by_key(|h| std::cmp::Reverse(h.score));
     hotspots.truncate(limit);
 
     hotspots
@@ -456,7 +456,7 @@ pub fn analyze_impact(metrics: &ProjectMetrics, module_name: &str) -> Option<Imp
                 })
                 .collect();
             // Sort by count descending
-            strength_list.sort_by(|a, b| b.count.cmp(&a.count));
+            strength_list.sort_by_key(|s| std::cmp::Reverse(s.count));
             DependencyInfo {
                 module: mod_name,
                 distance,
@@ -477,7 +477,7 @@ pub fn analyze_impact(metrics: &ProjectMetrics, module_name: &str) -> Option<Imp
                     count: c,
                 })
                 .collect();
-            strength_list.sort_by(|a, b| b.count.cmp(&a.count));
+            strength_list.sort_by_key(|s| std::cmp::Reverse(s.count));
             DependencyInfo {
                 module: mod_name,
                 distance,

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,7 +41,7 @@ use glob::Pattern;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use thiserror::Error;
 
 use crate::metrics::Volatility;
@@ -147,6 +147,8 @@ pub struct CompiledConfig {
     // === Analysis settings ===
     /// Whether to exclude test code from analysis
     pub exclude_tests: bool,
+    /// Directory containing the loaded config file, if any.
+    config_root: Option<PathBuf>,
     /// Patterns for prelude-like modules (exempt from afferent coupling warnings)
     prelude_patterns: Vec<Pattern>,
     /// Patterns for modules to completely exclude from analysis
@@ -174,6 +176,14 @@ pub struct CompiledConfig {
 impl CompiledConfig {
     /// Create a compiled config from raw config
     pub fn from_config(config: CouplingConfig) -> Result<Self, ConfigError> {
+        Self::from_config_with_root(config, None)
+    }
+
+    /// Create a compiled config from raw config and the directory containing that config file.
+    fn from_config_with_root(
+        config: CouplingConfig,
+        config_root: Option<&Path>,
+    ) -> Result<Self, ConfigError> {
         let compile_patterns = |patterns: &[String]| -> Result<Vec<Pattern>, ConfigError> {
             patterns
                 .iter()
@@ -186,6 +196,7 @@ impl CompiledConfig {
         Ok(Self {
             // Analysis settings
             exclude_tests: config.analysis.exclude_tests,
+            config_root: config_root.map(Path::to_path_buf),
             prelude_patterns: compile_patterns(&config.analysis.prelude_modules)?,
             exclude_patterns: compile_patterns(&config.analysis.exclude)?,
             // Volatility settings
@@ -203,6 +214,7 @@ impl CompiledConfig {
     pub fn empty() -> Self {
         Self {
             exclude_tests: false,
+            config_root: None,
             prelude_patterns: Vec::new(),
             exclude_patterns: Vec::new(),
             high_patterns: Vec::new(),
@@ -217,6 +229,11 @@ impl CompiledConfig {
     /// Set exclude_tests flag (used by CLI --exclude-tests option)
     pub fn set_exclude_tests(&mut self, exclude: bool) {
         self.exclude_tests = exclude;
+    }
+
+    /// Get the directory the config was loaded from, if known.
+    pub fn config_root(&self) -> Option<&Path> {
+        self.config_root.as_deref()
     }
 
     /// Check if a module is marked as "prelude-like" (exempt from afferent coupling warnings)
@@ -324,8 +341,36 @@ fn find_config_file(start_path: &Path) -> Option<std::path::PathBuf> {
 
 /// Load and compile configuration
 pub fn load_compiled_config(project_path: &Path) -> Result<CompiledConfig, ConfigError> {
-    let config = load_config(project_path)?;
-    CompiledConfig::from_config(config)
+    match find_config_file(project_path) {
+        Some(path) => {
+            let content = fs::read_to_string(&path)?;
+            let config: CouplingConfig = toml::from_str(&content)?;
+            let absolute_path = absolute_normalized_path(&path)?;
+            CompiledConfig::from_config_with_root(config, absolute_path.parent())
+        }
+        None => Ok(CompiledConfig::empty()),
+    }
+}
+
+fn absolute_normalized_path(path: &Path) -> Result<PathBuf, std::io::Error> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+
+    Ok(normalized)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,8 @@ pub mod workspace;
 
 pub use analyzer::{
     AnalyzedFileResult, AnalyzerError, CouplingAnalyzer, Dependency, DependencyKind, ItemDepType,
-    ItemDependency, ItemKind, analyze_project, analyze_rust_file, analyze_rust_file_full,
-    analyze_workspace,
+    ItemDependency, ItemKind, analyze_project, analyze_project_parallel_with_config,
+    analyze_rust_file, analyze_rust_file_full, analyze_workspace, analyze_workspace_with_config,
 };
 pub use balance::{
     BalanceInterpretation, BalanceScore, CouplingIssue, HealthGrade, IssueThresholds, IssueType,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use std::time::Instant;
 use clap::{Parser, Subcommand};
 
 use cargo_coupling::{
-    CompiledConfig, IssueThresholds, VolatilityAnalyzer, analyze_workspace,
+    CompiledConfig, IssueThresholds, VolatilityAnalyzer, analyze_workspace_with_config,
     cli_output::{
         CheckConfig, generate_check_output, generate_hotspots_output, generate_impact_output,
         generate_json_output, parse_grade, parse_severity,
@@ -233,7 +233,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     // Analyze the project (uses cargo metadata for better accuracy)
     let analysis_start = Instant::now();
-    let mut metrics = analyze_workspace(&args.path)?;
+    let mut metrics = analyze_workspace_with_config(&args.path, &config)?;
     let analysis_time = analysis_start.elapsed();
 
     // Analyze git history for volatility (if not disabled)

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -85,9 +85,10 @@ impl WorkspaceInfo {
         // Process all packages
         for package in &metadata.packages {
             let is_workspace_member = workspace_member_ids.contains(&package.id);
+            let package_name = package.name.to_string();
 
             if is_workspace_member {
-                members.push(package.name.clone());
+                members.push(package_name.clone());
             }
 
             // Get source directory
@@ -110,7 +111,7 @@ impl WorkspaceInfo {
 
                 // Build dependency graph
                 dependency_graph
-                    .entry(package.name.clone())
+                    .entry(package_name.clone())
                     .or_default()
                     .insert(dep.name.clone());
 
@@ -118,11 +119,11 @@ impl WorkspaceInfo {
                 reverse_deps
                     .entry(dep.name.clone())
                     .or_default()
-                    .insert(package.name.clone());
+                    .insert(package_name.clone());
             }
 
             let crate_info = CrateInfo {
-                name: package.name.clone(),
+                name: package_name.clone(),
                 id: package.id.clone(),
                 src_path,
                 manifest_path: package.manifest_path.as_std_path().to_path_buf(),
@@ -131,7 +132,7 @@ impl WorkspaceInfo {
                 is_workspace_member,
             };
 
-            crates.insert(package.name.clone(), crate_info);
+            crates.insert(package_name, crate_info);
         }
 
         Ok(Self {


### PR DESCRIPTION
## Summary
- preserve the discovered config root so analysis glob patterns keep the same meaning regardless of entry path
- apply `[analysis].exclude` filtering in both workspace analysis and the basic-analysis fallback path
- add regression tests for direct analysis, relative `./src` workspace analysis, and the non-workspace fallback path
- include a small `clippy` cleanup in `src/cli_output.rs` so the branch stays green under `-D warnings`

## Testing
- cargo test --all-features
- cargo clippy --all-targets --all-features -- -D warnings

Closes #39
